### PR TITLE
[BUG/Forward-translation-parameters]

### DIFF
--- a/src/Exception/TranslatableException.php
+++ b/src/Exception/TranslatableException.php
@@ -60,6 +60,16 @@ abstract class TranslatableException extends Exception
      */
     public function getTranslationParameters(): array
     {
-        return $this->translationParameters;
+        $wrapped = [];
+
+        foreach ($this->translationParameters as $key => $value) {
+            if (!str_starts_with($key, '%') || !str_ends_with($key, '%')) {
+                $key = "%{$key}%";
+            }
+
+            $wrapped[$key] = $value;
+        }
+
+        return $wrapped;
     }
 }

--- a/src/Exception/TranslatableException.php
+++ b/src/Exception/TranslatableException.php
@@ -63,7 +63,7 @@ abstract class TranslatableException extends Exception
         $wrapped = [];
 
         foreach ($this->translationParameters as $key => $value) {
-            if (!str_starts_with($key, '%') || !str_ends_with($key, '%')) {
+            if (! str_starts_with($key, '%') || ! str_ends_with($key, '%')) {
                 $key = "%{$key}%";
             }
 

--- a/src/Listener/ExceptionListener.php
+++ b/src/Listener/ExceptionListener.php
@@ -201,8 +201,8 @@ final class ExceptionListener
         $messageKey = "custom.{$e->getTranslationCode()}.message";
 
         return new ErrorRequestJsonResponse(
-            title: $this->translator->trans($titleKey, [], $this->exceptionTranslationDomain),
-            message: $this->translator->trans($messageKey, [], $this->exceptionTranslationDomain),
+            title: $this->translator->trans($titleKey, $e->getTranslationParameters(), $this->exceptionTranslationDomain),
+            message: $this->translator->trans($messageKey, $e->getTranslationParameters(), $this->exceptionTranslationDomain),
             // errors: [],
             statusCode: $e->getStatusCode(),
         );


### PR DESCRIPTION
The createResponseFromCustomException() method was passing empty array [] to translator->trans() instead of the exception's translation parameters. This caused error messages to display literal placeholders (e.g. %companyId%) instead of actual values.